### PR TITLE
[WIP] Spike limit events by proximity

### DIFF
--- a/plugins/liip/repaircafe/components/EventList.php
+++ b/plugins/liip/repaircafe/components/EventList.php
@@ -40,11 +40,10 @@ class EventList extends ComponentBase
         $distance = 100;
 
         $events = DB::select(
-            DB::raw('SELECT *,( 3959 * acos( cos( radians(' . $lat . ') ) * cos( radians( latitude ) ) * cos( radians( longitude ) - radians(' . $lng . ') ) + sin( radians(' . $lat .') ) * sin( radians(latitude) ) ) ) AS distance FROM liip_repaircafe_events HAVING distance < ' . $distance . ' ORDER BY distance')
+            DB::raw('SELECT *,( 3959 * acos( cos( radians(' . $lat . ') ) * cos( radians( latitude ) ) * cos( radians( longitude ) - radians(' . $lng . ') ) + sin( radians(' . $lat .') ) * sin( radians(latitude) ) ) ) AS distance FROM liip_repaircafe_events HAVING distance < ' . $distance . ' ORDER BY distance')  # noqa
         );
 
         return $events;
-
     }
 
     public function categories()

--- a/plugins/liip/repaircafe/components/EventList.php
+++ b/plugins/liip/repaircafe/components/EventList.php
@@ -1,6 +1,7 @@
 <?php namespace Liip\RepairCafe\Components;
 
 use Cms\Classes\ComponentBase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Lang;
 use Liip\RepairCafe\Models\Category;
@@ -29,6 +30,21 @@ class EventList extends ComponentBase
         }
 
         return $eventsGroupedByMonth;
+    }
+
+    public function eventsGroupedByProximity()
+    {
+        // St. Gallen Location
+        $lat = '47.42391';
+        $lng = '9.37477';
+        $distance = 100;
+
+        $events = DB::select(
+            DB::raw('SELECT *,( 3959 * acos( cos( radians(' . $lat . ') ) * cos( radians( latitude ) ) * cos( radians( longitude ) - radians(' . $lng . ') ) + sin( radians(' . $lat .') ) * sin( radians(latitude) ) ) ) AS distance FROM liip_repaircafe_events HAVING distance < ' . $distance . ' ORDER BY distance')
+        );
+
+        return $events;
+
     }
 
     public function categories()

--- a/plugins/liip/repaircafe/components/EventList.php
+++ b/plugins/liip/repaircafe/components/EventList.php
@@ -23,7 +23,7 @@ class EventList extends ComponentBase
     {
         $events = $this->queryEvents();
         $eventsGroupedByMonth = array();
-        foreach($events as $event) {
+        foreach ($events as $event) {
             $start = new \DateTime($event->start);
             $eventsGroupedByMonth[$start->format('Y')][$start->format('F')][] = $event;
         }
@@ -35,7 +35,7 @@ class EventList extends ComponentBase
     {
         $category_options = array();
         $category_options[] = Lang::get('liip.repaircafe::component.eventlist.all_categories');
-        foreach( $this->categories as $category ) {
+        foreach ($this->categories as $category) {
             $category_options[$category->slug] = $category->name;
         }
         return $category_options;

--- a/plugins/liip/repaircafe/components/EventList.php
+++ b/plugins/liip/repaircafe/components/EventList.php
@@ -1,10 +1,14 @@
 <?php namespace Liip\RepairCafe\Components;
 
 use Cms\Classes\ComponentBase;
+use Illuminate\Support\Facades\Input;
+use Liip\RepairCafe\Models\Category;
 use Liip\RepairCafe\Models\Event;
 
 class EventList extends ComponentBase
 {
+    private $categories;
+
     public function componentDetails()
     {
         return [
@@ -16,10 +20,47 @@ class EventList extends ComponentBase
     // This array becomes available on the page as {{ component.eventsGroupedByMonth }}
     public function eventsGroupedByMonth()
     {
-        $events = Event::all();
+        $events = $this->queryEvents();
         return array(
             'August' => $events,
             'September' => $events,
         );
+    }
+
+    public function categories()
+    {
+        return $this->categories;
+    }
+
+    public function onRun()
+    {
+        $this->events = $this->queryEvents();
+        $this->categories = Category::all();
+    }
+
+    protected function queryEvents()
+    {
+        $category = Input::get('category');
+        $searchTerm = Input::get('searchterm');
+
+        if (!empty($searchTerm) && !empty($category)) {
+            $events = Event::whereHas('categories', function ($filter) use ($category) {
+                $filter->where('slug', '=', $category);
+            })
+            ->where(function ($searchFilter) use ($searchTerm) {
+                $searchFilter->where('title', 'like', '%'.$searchTerm.'%')
+                    ->orWhere('description', 'like', '%'.$searchTerm.'%');
+            })->get();
+        } elseif (!empty($searchTerm)) {
+            $events = Event::where('title', 'like', '%'.$searchTerm.'%')
+                ->orWhere('description', 'like', '%'.$searchTerm.'%')->get();
+        } elseif (!empty($category)) {
+            $events = Event::whereHas('categories', function ($filter) use ($category) {
+                $filter->where('slug', '=', $category);
+            })->get();
+        } else {
+            $events = Event::all();
+        }
+        return $events;
     }
 }

--- a/plugins/liip/repaircafe/components/EventList.php
+++ b/plugins/liip/repaircafe/components/EventList.php
@@ -68,12 +68,13 @@ class EventList extends ComponentBase
                 $filter->where('slug', '=', $category);
             });
         } else {
-            $query = Event::orderBy('start', 'asc'); // TODO do not order twice
+            $query = Event::query();
         }
 
-        $query->join('liip_repaircafe_cafes', 'liip_repaircafe_events.cafe_id', '=', 'liip_repaircafe_cafes.id');
-        $query->where('liip_repaircafe_cafes.is_published', true);
-        $query->where('liip_repaircafe_events.is_published', true);
+        $query->whereHas('cafe', function ($cafe) {
+            $cafe->where('is_published', true);
+        });
+        $query->where('is_published', true);
         $query->orderBy('start', 'asc');
         $events = $query->get();
 

--- a/plugins/liip/repaircafe/components/EventList.php
+++ b/plugins/liip/repaircafe/components/EventList.php
@@ -34,7 +34,7 @@ class EventList extends ComponentBase
     public function categories()
     {
         $category_options = array();
-        $category_options[] = Lang::get('liip.repaircafe::component.eventlist.all_categories');
+        $category_options[] = Lang::get('liip.repaircafe::lang.component.eventlist.all_categories');
         foreach ($this->categories as $category) {
             $category_options[$category->slug] = $category->name;
         }

--- a/plugins/liip/repaircafe/components/eventlist/default.htm
+++ b/plugins/liip/repaircafe/components/eventlist/default.htm
@@ -1,46 +1,48 @@
 <div class="eventlist">
-    {% for month, events in __SELF__.eventsGroupedByMonth %}
-    <h2>{{ month }}</h2>
-    <ul class="list-unstyled mb-5">
-        {% for event in events %}
-        <li class="pt-3">
-            <div class="row">
-                <div class="col-md-6 media mb-3">
-                    <img class="d-flex mr-3 logo" src="{{ event.cafe.logo.path }}" alt="{{ event.cafe.title }}">
-                    <div class="media-body">
-                        <h3 class="h5"><a href="{{ 'cafe'|page({ slug: event.cafe.slug }) }}">{{ event.cafe.title }}: {{ event.title }}</a></h3>
-                        <p class="small">
-                            {% if event.start|date('d.m.Y') == event.end|date('d.m.Y') %}
-                                {{ event.start|date('d.m.Y') }}<br />
-                            {% else %}
-                                {{ event.start|date('d.m.Y') }} - {{ event.end|date('d.m.Y') }}<br />
-                            {% endif %}
-                            {{ event.start|date('H:s') }} - {{ event.end|date('H:s') }}<br />
-                            TODO: address
-                        </p>
+    {% for year, months in __SELF__.eventsGroupedByMonth %}
+        {% for month, events in months %}
+        <h2>{{ month }} {{ year }}</h2>
+        <ul class="list-unstyled mb-5">
+            {% for event in events %}
+            <li class="pt-3">
+                <div class="row">
+                    <div class="col-md-6 media mb-3">
+                        <img class="d-flex mr-3 logo" src="{{ event.cafe.logo.path }}" alt="{{ event.cafe.title }}">
+                        <div class="media-body">
+                            <h3 class="h5"><a href="{{ 'cafe'|page({ slug: event.cafe.slug }) }}">{{ event.cafe.title }}: {{ event.title }}</a></h3>
+                            <p class="small">
+                                {% if event.start|date('d.m.Y') == event.end|date('d.m.Y') %}
+                                    {{ event.start|date('d.m.Y') }}<br />
+                                {% else %}
+                                    {{ event.start|date('d.m.Y') }} - {{ event.end|date('d.m.Y') }}<br />
+                                {% endif %}
+                                {{ event.start|date('H:s') }} - {{ event.end|date('H:s') }}<br />
+                                TODO: address
+                            </p>
+                        </div>
+                    </div>
+                    <div class="col-md-6 mb-3">
+                        <button type="button" class="close collapsed" data-toggle="collapse" data-target="#eventAdditionalInfo{{ event.id }}" aria-expanded="false" aria-controls="#eventAdditionalInfo{{ event.id }}">
+                            <i class="fa fa-chevron-toggle" aria-hidden="true"></i>
+                        </button>
+                        <ul class="list-unstyled">
+                            {% for category in event.categories %}
+                                <li>{{ category.name }}</li>
+                            {% endfor %}
+                        </ul>
                     </div>
                 </div>
-                <div class="col-md-6 mb-3">
-                    <button type="button" class="close collapsed" data-toggle="collapse" data-target="#eventAdditionalInfo{{ event.id }}" aria-expanded="false" aria-controls="#eventAdditionalInfo{{ event.id }}">
-                        <i class="fa fa-chevron-toggle" aria-hidden="true"></i>
-                    </button>
-                    <ul class="list-unstyled">
-                        {% for category in event.categories %}
-                            <li>{{ category.name }}</li>
-                        {% endfor %}
-                    </ul>
+                <div class="row additional-info collapse" id="eventAdditionalInfo{{ event.id }}">
+                    <div class="col-md-6 mb-3">
+                        <img src="http://livedoor.blogimg.jp/netouyonews/imgs/c/c/cc791ed6.jpg" class="img-fluid" />
+                    </div>
+                    <div class="col-md-6 mb-3 small">
+                        {{ event.description|raw }}
+                    </div>
                 </div>
-            </div>
-            <div class="row additional-info collapse" id="eventAdditionalInfo{{ event.id }}">
-                <div class="col-md-6 mb-3">
-                    <img src="http://livedoor.blogimg.jp/netouyonews/imgs/c/c/cc791ed6.jpg" class="img-fluid" />
-                </div>
-                <div class="col-md-6 mb-3 small">
-                    {{ event.description|raw }}
-                </div>
-            </div>
-        </li>
+            </li>
+            {% endfor %}
+        </ul>
         {% endfor %}
-    </ul>
     {% endfor %}
 </div>

--- a/plugins/liip/repaircafe/lang/en/lang.php
+++ b/plugins/liip/repaircafe/lang/en/lang.php
@@ -37,7 +37,6 @@
         'events' => 'Events',
         'contacts' => 'Contacts',
         'categories' => 'Categories',
-        'contacts' => 'Contacts',
     ],
     'nav' => [
         'cafes' => 'Cafes',
@@ -74,5 +73,10 @@
     'category' => [
         'name' => 'Name',
         'slug' => 'Slug',
+    ],
+    'component' => [
+        'eventlist' => [
+            'all_categories' => 'All Categories',
+        ],
     ],
 ];

--- a/plugins/liip/repaircafe/models/Cafe.php
+++ b/plugins/liip/repaircafe/models/Cafe.php
@@ -24,7 +24,7 @@ class Cafe extends Model
      *
      * @var array
      */
-    protected $fillable = ['title', 'description', 'street', 'zip', 'city', 'slug', 'contacts'];
+    protected $fillable = ['title', 'description', 'street', 'zip', 'city', 'slug', 'contacts', 'is_published'];
 
     /*
      * Validation

--- a/plugins/liip/repaircafe/models/Cafe.php
+++ b/plugins/liip/repaircafe/models/Cafe.php
@@ -9,8 +9,13 @@ use System\Models\File;
 class Cafe extends Model
 {
     use \October\Rain\Database\Traits\Validation;
-
     use \October\Rain\Database\Traits\SoftDelete;
+    use \October\Rain\Database\Traits\Sluggable;
+
+    /**
+     * @var array Generate slugs for these attributes.
+     */
+    protected $slugs = ['slug' => 'name'];
 
     protected $dates = ['deleted_at'];
 

--- a/plugins/liip/repaircafe/models/Category.php
+++ b/plugins/liip/repaircafe/models/Category.php
@@ -8,6 +8,12 @@ use October\Rain\Database\Model;
 class Category extends Model
 {
     use \October\Rain\Database\Traits\Validation;
+    use \October\Rain\Database\Traits\Sluggable;
+
+    /**
+     * @var array Generate slugs for these attributes.
+     */
+    protected $slugs = ['slug' => 'name'];
 
     /*
      * Disable timestamps by default.

--- a/plugins/liip/repaircafe/models/Event.php
+++ b/plugins/liip/repaircafe/models/Event.php
@@ -16,7 +16,7 @@ class Event extends Model
      *
      * @var array
      */
-    protected $fillable = ['title', 'description', 'start', 'end', 'cafe_id'];
+    protected $fillable = ['title', 'description', 'start', 'end', 'cafe_id', 'is_published'];
 
     protected $dates = ['deleted_at'];
 

--- a/plugins/liip/repaircafe/seeds/Cafes.yaml
+++ b/plugins/liip/repaircafe/seeds/Cafes.yaml
@@ -5,6 +5,7 @@
   zip: 8810
   city: Horgen
   slug: flick-kafi-horgen
+  is_published: true
   contacts:
   -
     firstname: Urs
@@ -33,13 +34,16 @@
     description: Die ganze Schweiz kommt zusammen in Bern um gemeinsam alte Geräte zu reparieren.
     start: '2017-11-13 09:30:00.00'
     end: '2017-11-13 19:00:00.00'
+    is_published: true
   -
     title: 13. Flick-Kafi-Tag
     description: Wie gewohnt in Horgen.
     start: '2017-12-08 09:30:00.00'
     end: '2017-12-08 19:00:00.00'
+    is_published: true
   -
     title: 14. Flick-Kafi-Tag
     description: Kurz vor Weihnachten wird es zum Kaffee zusätzlich Kuchen geben.
     start: '2017-12-18 09:30:00.00'
     end: '2017-12-18 19:00:00.00'
+    is_published: true

--- a/themes/repair-cafe/assets/js/app.js
+++ b/themes/repair-cafe/assets/js/app.js
@@ -1,1 +1,5 @@
-console.log('hi');
+$( document ).ready(function() {
+    $('#eventSearch select[name="category"]').change(function() {
+        this.form.submit();
+    });
+});

--- a/themes/repair-cafe/pages/events.htm
+++ b/themes/repair-cafe/pages/events.htm
@@ -18,16 +18,11 @@ localeUrl[de] = "/eventlist"
                         {{ form_open({ class: 'form-inline justify-content-center', url: url('events'), method: 'GET' }) }}
                             <div class="search-input-group has-btn-embed has-btn-embed-right mr-sm-2 mb-2 mb-sm-0">
                                 <label for="searchterm" class="sr-only">{{ 'eventlist.search.searchterm.label'|_ }}</label>
-                                <input class="form-control form-control-lg text-truncate" type="search" placeholder="{{ 'eventlist.search.searchterm.placeholder'|_ }}" id="searchterm" name="searchterm">
+                                {{ form_input( 'search', 'searchterm', input('searchterm'), { class: 'form-control form-control-lg text-truncate', placeholder: 'eventlist.search.searchterm.placeholder'|_ } ) }}
                                 <button type="submit" class="btn btn-embed btn-embed-lg"><i class="fa fa-search" aria-hidden="true"></i></button>
                             </div>
                             <label for="category" class="sr-only">{{ 'eventlist.search.category.label'|_ }}</label>
-                            <select class="form-control form-control-lg" id="category" name="category">
-                                <option value="">Alle Kategorien</option>
-                                {% for category in eventList.categories %}
-                                    <option value="{{category.slug}}">{{category.name}}</option>
-                                {% endfor %}
-                            </select>
+                            {{ form_select( 'category', eventList.categories, input('category'), { class: 'form-control form-control-lg' } ) }}
                         {{ form_close() }}
                     </div>
                 </div>

--- a/themes/repair-cafe/pages/events.htm
+++ b/themes/repair-cafe/pages/events.htm
@@ -15,7 +15,7 @@ localeUrl[de] = "/eventlist"
                 <div class="page-header-content row">
                     <div class="offset-lg-2 col-lg-8">
                         <h1>{{ 'eventlist.title'|_ }}</h1>
-                        {{ form_open({ class: 'form-inline justify-content-center' }) }}
+                        {{ form_open({ class: 'form-inline justify-content-center', url: url('events'), method: 'GET' }) }}
                             <div class="search-input-group has-btn-embed has-btn-embed-right mr-sm-2 mb-2 mb-sm-0">
                                 <label for="searchterm" class="sr-only">{{ 'eventlist.search.searchterm.label'|_ }}</label>
                                 <input class="form-control form-control-lg text-truncate" type="search" placeholder="{{ 'eventlist.search.searchterm.placeholder'|_ }}" id="searchterm" name="searchterm">
@@ -23,9 +23,10 @@ localeUrl[de] = "/eventlist"
                             </div>
                             <label for="category" class="sr-only">{{ 'eventlist.search.category.label'|_ }}</label>
                             <select class="form-control form-control-lg" id="category" name="category">
-                                <option value="1">Alle Kategorien</option>
-                                <option value="1">Velo</option>
-                                <option value="2">Handy</option>
+                                <option value="">Alle Kategorien</option>
+                                {% for category in eventList.categories %}
+                                    <option value="{{category.slug}}">{{category.name}}</option>
+                                {% endfor %}
                             </select>
                         {{ form_close() }}
                     </div>

--- a/themes/repair-cafe/pages/events.htm
+++ b/themes/repair-cafe/pages/events.htm
@@ -15,7 +15,7 @@ localeUrl[de] = "/eventlist"
                 <div class="page-header-content row">
                     <div class="offset-lg-2 col-lg-8">
                         <h1>{{ 'eventlist.title'|_ }}</h1>
-                        {{ form_open({ class: 'form-inline justify-content-center', url: url('events'), method: 'GET' }) }}
+                        {{ form_open({ class: 'form-inline justify-content-center', url: url('events'), method: 'GET', id: 'eventSearch' }) }}
                             <div class="search-input-group has-btn-embed has-btn-embed-right mr-sm-2 mb-2 mb-sm-0">
                                 <label for="searchterm" class="sr-only">{{ 'eventlist.search.searchterm.label'|_ }}</label>
                                 {{ form_input( 'search', 'searchterm', input('searchterm'), { class: 'form-control form-control-lg text-truncate', placeholder: 'eventlist.search.searchterm.placeholder'|_ } ) }}


### PR DESCRIPTION
Demonstrates how to filter (and sort) events by their proximity.

This needs DB-fields: `events.latitude` and `events.longitude` to be merged.