### PR TITLE
display repaircafe-tab for owner-role only

### DIFF
--- a/plugins/liip/repaircafe/Plugin.php
+++ b/plugins/liip/repaircafe/Plugin.php
@@ -10,6 +10,7 @@ use Liip\RepairCafe\Models\News;
 use October\Rain\Support\Facades\Html;
 use RainLab\Translate\Classes\Translator;
 use System\Classes\PluginBase;
+use Backend\Facades\BackendAuth;
 
 class Plugin extends PluginBase
 {
@@ -109,8 +110,8 @@ class Plugin extends PluginBase
             if (!$model instanceof BackendUserModel) {
                 return;
             }
-
-            if ($model->hasRole('owners')) {
+            $backend_user = BackendAuth::getUser();
+            if ($backend_user->hasRole('owners') && $model->hasRole('repaircafeOrganisator')) {
                 $form->addTabFields([
                     'cafes' => [
                         'label' => 'liip.repaircafe::lang.user.tab.cafe_label',


### PR DESCRIPTION
1. check if backend_user is allowed to assign repaircafeOrganisators to repaircafes (Owner-Role)
2. only repaircafeOrganisator-users can be assigned to a repaircafe (repaircafeOrganisator-Role)